### PR TITLE
Parse data not in a data structure

### DIFF
--- a/JSONParser.class.nut
+++ b/JSONParser.class.nut
@@ -253,7 +253,8 @@ class JSONParser {
 
     // current tokenizeing position
     local start = 0;
-
+    local lastToken = null;
+      
     try {
 
       local
@@ -262,7 +263,8 @@ class JSONParser {
         tokenizer = _JSONTokenizer();
 
       while (token = tokenizer.nextToken(str, start)) {
-
+        lastToken = token;
+          
         if ("ptfn" == token.type) {
           // punctuation/true/false/null
           action[token.value][state]();
@@ -284,13 +286,18 @@ class JSONParser {
     }
 
     // check is the final state is not ok
-    // or if there is somethign left in the str
+    // or if there is something left in the str
     if (state != "ok" || regexp("[^\\s]").capture(str, start)) {
       local min = @(a, b) a < b ? a : b;
       local near = str.slice(start, min(str.len(), start + 10));
       throw "JSON Syntax Error near `" + near + "`";
     }
 
+    // if this is a standalone string or number, convert it
+    if (lastToken.type == "string" || lastToken.type == "number") {
+      return this._convert(lastToken.value, lastToken.type, converter, null)
+    }
+      
     return value;
   }
 

--- a/JSONParser.class.nut
+++ b/JSONParser.class.nut
@@ -246,25 +246,20 @@ class JSONParser {
       }
     };
 
-    //
-
     state = "go";
     stack = [];
 
     // current tokenizeing position
     local start = 0;
-    local lastToken = null;
-      
-    try {
-
-      local
+    local
         result,
         token,
+        lastToken,
         tokenizer = _JSONTokenizer();
-
+        
+    try {
       while (token = tokenizer.nextToken(str, start)) {
         lastToken = token;
-          
         if ("ptfn" == token.type) {
           // punctuation/true/false/null
           action[token.value][state]();
@@ -280,7 +275,6 @@ class JSONParser {
 
         start += token.length;
       }
-
     } catch (e) {
       state = e;
     }
@@ -295,7 +289,7 @@ class JSONParser {
 
     // if this is a standalone string or number, convert it
     if (lastToken.type == "string" || lastToken.type == "number") {
-      return this._convert(lastToken.value, lastToken.type, converter, null)
+      return this._convert(lastToken.value, lastToken.type, converter)
     }
       
     return value;
@@ -374,7 +368,6 @@ class _JSONTokenizer {
    * @return {{type,value,length}|null}
    */
   function nextToken(str, start = 0) {
-
     local
       m,
       type,

--- a/JSONParser.class.nut
+++ b/JSONParser.class.nut
@@ -246,20 +246,25 @@ class JSONParser {
       }
     };
 
+    //
+
     state = "go";
     stack = [];
 
     // current tokenizeing position
     local start = 0;
-    local
+    local lastToken = null;
+      
+    try {
+
+      local
         result,
         token,
-        lastToken,
         tokenizer = _JSONTokenizer();
-        
-    try {
+
       while (token = tokenizer.nextToken(str, start)) {
         lastToken = token;
+          
         if ("ptfn" == token.type) {
           // punctuation/true/false/null
           action[token.value][state]();
@@ -275,6 +280,7 @@ class JSONParser {
 
         start += token.length;
       }
+
     } catch (e) {
       state = e;
     }
@@ -368,6 +374,7 @@ class _JSONTokenizer {
    * @return {{type,value,length}|null}
    */
   function nextToken(str, start = 0) {
+
     local
       m,
       type,


### PR DESCRIPTION
The current implementation of JSONParser does not correctly parse data not in a structure, like a single integer or float.  In example:

```squirrel
local a = "77";
local b = JSONParser.parse(a)
server.log("Value " + b + " has type " + typeof b)

local c = http.jsondecode("77")
server.log("Value " + c + " has type " + typeof c)
```

Returns:

```
Value 77 has type string
Value 77 has type integer
```

I've added a few lines of code to save the last state of the state machine as to make JSONParser more consistent with `http.jsondecode()`'s implementation.