### PR TITLE
Pass key in custom converter function -- updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Squirrel JSON Parser 1.0.2 #
+# Squirrel JSON Parser 2.0.0 #
 
 This library parses JSON into Squirrel data types.
 
-**To include this library in your project, add** `#require "JSONParser.class.nut:1.0.2"` **at the top of your code.**
+**To include this library in your project, add** `#require "JSONParser.class.nut:2.0.0"` **at the top of your code.**
 
 ![Build Status](https://cse-ci.electricimp.com/app/rest/builds/buildType:(id:JSONParser_BuildAndTest)/statusIcon)
 
@@ -10,7 +10,7 @@ This library parses JSON into Squirrel data types.
 
 JSONParser has no constructor and one public function, *parse()*.
 
-### parse(*jsonString[, converter]*)
+### parse(*jsonString[, converter]*) ###
 
 This method converts the supplied JSON to a table.
 
@@ -27,6 +27,7 @@ An optional converter function can be passed into *parse()* to de-serialize cust
 
 - *value* &mdash; String representation of a value.
 - *type* &mdash; String indicating conversion type: `"string"` or `"number"`.
+- *key* &mdash; If the value is in a table, this is the value's key.
 
 For example, the following code converts all numbers to floats and makes strings uppercase:
 
@@ -78,7 +79,7 @@ s <- JSONEncoder.encode(o);
 server.log(s);
 // Displays '{"a":1,"c":"@mycustomtype:100500","b":"Something"}'
 
-result <- JSONParser.parse(s, function (val, type) {
+result <- JSONParser.parse(s, function (val, type, key) {
     if ("number" == type) {
         return val.tofloat();
     } else if ("string" == type) {

--- a/tests/badData.agent.test.nut
+++ b/tests/badData.agent.test.nut
@@ -1,0 +1,89 @@
+/*
+ * Check for failure when passed bad JSON encoded string
+ */
+class badData extends ImpTestCase {
+
+    function testBadBasic() {
+        // local data = {
+        //     "a" : 1,
+        //     "b" : 2,
+        //     "c" : 3,
+        // };
+        // this.info(JSONEncoder.encode(data))
+
+        // delete a comma
+        this.assertThrowsError(JSONParser.parse, JSONParser, ["{\"a\":1\"c\":3,\"b\":2}"]);
+
+        // delete a curly bracket
+        this.assertThrowsError(JSONParser.parse, JSONParser, ["\"a\":1,\"c\":3,\"b\":2}"]);
+
+        // delete the value
+        this.assertThrowsError(JSONParser.parse, JSONParser, ["{\"a\":1,\"c\":,\"b\":2}"]);
+
+        // delete a colon
+        this.assertThrowsError(JSONParser.parse, JSONParser, ["{\"a\"1,\"c\":3,\"b\":2}"]);
+
+        // delete the other bracket
+        this.assertThrowsError(JSONParser.parse, JSONParser, ["{\"a\":1,\"c\":3,\"b\":2"]);
+
+        // delete all the quotes
+        this.assertThrowsError(JSONParser.parse, JSONParser, ["{a:1,c:3,b:2}"]);
+    }
+
+    function testBadArray() {
+        // local data1 = {
+        //     a = [1,2,3],
+        //     b = ["A", "B", "C"],
+        //     c = [1.1, 2.2, 3.3]
+        // };
+        // this.info(JSONEncoder.encode(data1))
+
+        // delete a bracket
+        this.assertThrowsError(JSONParser.parse, JSONParser, ["\"a\":[1,2,3],\"c\":[1.1,2.2,3.3],\"b\":[\"A\",\"B\",\"C\"]}"]);
+        this.assertThrowsError(JSONParser.parse, JSONParser, ["{\"a\":[1,2,3],\"c\":[1.1,2.2,3.3],\"b\":[\"A\",\"B\",\"C\"]"]);
+
+        // delete a square bracket
+        this.assertThrowsError(JSONParser.parse, JSONParser, ["{\"a\":[1,2,3],\"c\":[1.1,2.2,3.3],\"b\":[\"A\",\"B\",\"C\"}"]);
+        this.assertThrowsError(JSONParser.parse, JSONParser, ["{\"a\":[1,2,3],\"c\":1.1,2.2,3.3],\"b\":[\"A\",\"B\",\"C\"]}"]);
+        this.assertThrowsError(JSONParser.parse, JSONParser, ["{\"a\":[1,2,3,\"c\":[1.1,2.2,3.3],\"b\":[\"A\",\"B\",\"C\"]}"]);
+
+        // destroy colons
+        this.assertThrowsError(JSONParser.parse, JSONParser, ["{\"a\"[1,2,3],\"c\"[1.1,2.2,3.3],\"b\"[\"A\",\"B\",\"C\"]}"]);
+
+
+        // local data2 = [1, 2, "red", "blue", {"a": "table"}];
+        // this.info(JSONEncoder.encode(data2))
+        // "[1,2,\"red\",\"blue\",{\"a\":\"table\"}]"
+
+        this.assertThrowsError(JSONParser.parse, JSONParser, ["1,2,\"red\",\"blue\",{\"a\":\"table\"}]"]);
+        this.assertThrowsError(JSONParser.parse, JSONParser, ["[1,2,\"red\",\"blue\",{\"a\":\"table\"}"]);
+        this.assertThrowsError(JSONParser.parse, JSONParser, ["[1,2,\"red\",\"blue\",{\"a\":\"table\"]"]);
+        this.assertThrowsError(JSONParser.parse, JSONParser, ["[1,2,\"red\",\"blue\",\"a\":\"table\"}]"]);
+        this.assertThrowsError(JSONParser.parse, JSONParser, ["[1,2,\"red\",\"blue\",{\"a\"\"table\"}]"]);
+        this.assertThrowsError(JSONParser.parse, JSONParser, ["[1,2\"red\"\"blue\"{\"a\":\"table\"}]"]);
+    }
+
+    function testBadTable() {
+        // local data = {
+        //     "a" : [1,2,3],
+        //     "b" : "Hello world!"
+        //     "c" : 1598.677
+        // };
+        // this.info(JSONEncoder.encode(data))
+
+        // remove commas
+        this.assertThrowsError(JSONParser.parse, JSONParser, ["{\"a\":[1,2,3],\"c\":1598.68\"b\":\"Hello world!\"}"])
+        this.assertThrowsError(JSONParser.parse, JSONParser, ["{\"a\":[1,2,3]\"c\":1598.68,\"b\":\"Hello world!\"}"])
+
+        // remove brackets
+        this.assertThrowsError(JSONParser.parse, JSONParser, ["{\"a\":[1,2,3],\"c\":1598.68,\"b\":\"Hello world!\""])
+        this.assertThrowsError(JSONParser.parse, JSONParser, ["\"a\":[1,2,3],\"c\":1598.68,\"b\":\"Hello world!\"}"])
+
+        // and quotation marks
+        this.assertThrowsError(JSONParser.parse, JSONParser, ["{\"a\":[1,2,3],\"c:1598.68,\"b\":\"Hello world!\"}"])
+        this.assertThrowsError(JSONParser.parse, JSONParser, ["{\"a\":[1,2,3],\"c\":1598.68,\"b\":\"Hello world!}"])
+
+        // whole chunk of data missing
+        this.assertThrowsError(JSONParser.parse, JSONParser, ["{\"a\":,\"c\":1598.68,\"b\":\"Hello world!\"}"])
+    }
+}

--- a/tests/converter.agent.test.nut
+++ b/tests/converter.agent.test.nut
@@ -27,7 +27,7 @@ class Custom_Converter_TestCase extends ImpTestCase {
     local s = "{\"a\":1,\"c\":\"@mycustomtype:abc\",\"b\":2}";
 
     // use custom conveter to revreate MyCustomType
-    local d = JSONParser.parse(s, function (val, type) {
+    local d = JSONParser.parse(s, function (val, type, key) {
       if ("number" == type) {
         return val.tofloat();
       } else if ("string" == type) {
@@ -41,5 +41,92 @@ class Custom_Converter_TestCase extends ImpTestCase {
 
     this.assertTrue(d.c instanceof MyCustomType);
     this.assertTrue(d.c.getValue() == "abc");
+  }
+
+  function test_2() {
+    local s = "\"Hello world!\"";
+    local d = JSONParser.parse(s, function(value, type, key){
+      if (type == "string") {
+        return value;
+      } else if (type == "number") {
+        throw "JSONParse passed wrong type!"
+      } else {
+        throw "JSONParse passed invalid type!"
+      }
+    });
+
+    this.assertDeepEqual("Hello world!", d)
+  }
+
+  function test_3() {
+    // Arrays with custom parsing
+    local s = "[1,2,3]";
+    local d = JSONParser.parse(s, function(value, type, key){
+      if (type == "string") {
+        throw "JSONParse passed wrong type!"
+      } else if (type == "number") {
+        return value.tointeger();
+      } else {
+        throw "JSONParse passed invalid type!"
+      }
+    });
+
+    this.assertDeepEqual([1,2,3], d)
+  }
+
+  function test_4() {
+    // Integers with custom parsing
+    local s = "77";
+    local d = JSONParser.parse(s, function(value, type, key){
+      if (type == "string") {
+        throw "JSONParse passed wrong type!"
+      } else if (type == "number") {
+        return value.tointeger();
+      } else {
+        throw "JSONParse passed invalid type!"
+      }
+    });
+
+    this.assertDeepEqual(77, d)
+  }
+
+  function test_5() {
+    local s = "77.8";
+    local d = JSONParser.parse(s, function(value, type, key){
+      if (type == "string") {
+        throw "JSONParse passed wrong type!"
+      } else if (type == "number") {
+        return value.tofloat();
+      } else {
+        throw "JSONParse passed invalid type!"
+      }
+    });
+
+    this.assertDeepEqual(77.8, d)
+  }
+
+  function test_6() {
+    local s = "{\"a\":\"Hello world!\",\"c\":1.667,\"b\":1024}"
+    local d = JSONParser.parse(s, function(value, type, key){
+      if (type == "string" && key == "a") {
+        return value;
+      } else if (type == "number") {
+        if (key == "c") {
+          return value.tofloat();
+        } else if (key == "b") {
+          return value.tointeger();
+        } else {
+          throw "JSONParse passed bad key!"
+        }
+      } else {
+        throw "JSONParse key testing failed!"
+      }
+    });
+
+    this.assertDeepEqual({
+          a = "Hello world!",
+          b = 1024,
+          c = 1.667
+        }, d)
   }
 }

--- a/tests/parse.agent.test.nut
+++ b/tests/parse.agent.test.nut
@@ -108,6 +108,24 @@ class Parsing_TestCase extends ImpTestCase {
   function test_5() {
     local s = "77";
     local d = JSONParser.parse(s);
-    this.assertDeepEqual(d, 77);
+    this.assertDeepEqual(77, d);
+  }
+
+  function test_6() {
+    local s = "\"Hello world!\"";
+    local d = JSONParser.parse(s)
+    this.assertDeepEqual("Hello world!", d)
+  }
+
+  function test_7() {
+      local s = "77.8";
+      local d = JSONParser.parse(s);
+      this.assertDeepEqual(77.8, d);
+  }
+
+  function test_8() {
+      local s = "[1,2,3]";
+      local d = JSONParser.parse(s);
+      this.assertDeepEqual([1,2,3], d);
   }
 }


### PR DESCRIPTION
This PR extends the modifications made in PR #7 to work with the ability to convert data not in a structure (PR #14).  
I have:
* Added tests for the custom converter function, including checking keys.
* Added tests to ensure bad data is being rejected.
* Added tests to ensure data not in a structure is being processed correctly
* Updated README examples and version numbers

@betzrhodes I am aware that `getinfos` support is in the works, but with the version control system in place, users can `#require` the 1.0.2 release or the 2.0.0 release with this feature, that way the change doesn't need to break existing code.

I hope this helps address some of the blockers!